### PR TITLE
Biomarker Normalization

### DIFF
--- a/harvester/cgi_biomarkers.py
+++ b/harvester/cgi_biomarkers.py
@@ -6,33 +6,9 @@ import copy
 import cosmic_lookup_table
 import evidence_label as el
 import evidence_direction as ed 
-
+import mutation_type as mut
 
 """ https://www.cancergenomeinterpreter.org/biomarkers """
-
-def _get_biomarker_type(alteration_type, biomarker):
-    """ Map alteration type to standardized biomarker type. """
-
-    # Dictionary to look up simple types.
-    ALTERATION_TYPE_TO_BIOMARKER_TYPE = {
-        "BIA":  "biallelic inactivation",
-        "EXPR": "overexpression",
-        "FUS": "fusion",
-        "MUT": "snp"
-    }
-
-    rval = ''
-    if alteration_type in ALTERATION_TYPE_TO_BIOMARKER_TYPE:
-        rval = ALTERATION_TYPE_TO_BIOMARKER_TYPE[alteration_type]
-    elif alteration_type == "CNA":
-        # Copy number alteration, either amplification or deletion.
-        if "amplification" in biomarker:
-            rval = "amplification"
-        elif "deletion" in biomarker:
-            rval = "deletion"
-
-    return rval
-
 
 def _get_evidence(gene_ids, path='./cgi_biomarkers_per_variant.tsv'):
     """ load tsv """
@@ -93,7 +69,7 @@ def convert(evidence):
     gene = evidence['Gene']
     feature = split_gDNA(evidence['gDNA'])
 
-    feature['biomarker_type'] = _get_biomarker_type(evidence['Alteration type'], evidence['Biomarker'])
+    feature['biomarker_type'] = mut.norm_biomarker(evidence['Alteration type'], evidence['Biomarker'])
     feature['geneSymbol'] = gene
     feature['name'] = evidence['Biomarker']
     feature['description'] = evidence['Alteration']

--- a/harvester/civic.py
+++ b/harvester/civic.py
@@ -4,6 +4,7 @@ import requests
 import copy
 import evidence_label as el
 import evidence_direction as ed
+import mutation_type as mut
 
 def harvest(genes):
     """ given an array of gene symbols, harvest them from civic"""
@@ -50,6 +51,7 @@ def convert(gene_data):
             feature['referenceName'] = str(variant['coordinates']['reference_build'])  # NOQA
             feature['chromosome'] = str(variant['coordinates']['chromosome'])
             feature['name'] = variant['name']
+            feature['biomarker_type'] = mut.norm_biomarker(variant['variant_types'][0]['display_name']) # NOQA
             for evidence_item in variant['evidence_items']:
                 association = {}
                 association['description'] = evidence_item['description']

--- a/harvester/jax.py
+++ b/harvester/jax.py
@@ -8,6 +8,7 @@ from inflection import parameterize, underscore
 import json
 import evidence_label as el
 import evidence_direction as ed
+import mutation_type as mut
 
 import cosmic_lookup_table
 
@@ -100,6 +101,7 @@ def convert(jax_evidence):
             feature = {}
             feature['geneSymbol'] = gene
             feature['name'] = evidence['molecular_profile']
+            feature['biomarker_type'] = mut.norm_biomarker(None)
 
             try:
                 gene, alteration = molecular_profile_fields[index:index+2]

--- a/harvester/mutation_type.py
+++ b/harvester/mutation_type.py
@@ -1,0 +1,45 @@
+
+
+def norm_biomarker(evidence, cgi_biomarker=None):
+    """ Map alteration type to standardized biomarker type. """
+    if evidence:
+        ev = evidence.lower()
+    else:
+        return 'NA'
+
+    # Note that 'CNA' is currently left out as it is relevant only in the case
+    # of CGI and directed in for loop below. 
+    mut_types = {
+        'fusion' : ['fusion', 'fus'],
+        'snp' : ['snp', 'mut', 'missense', 'protein altering', 'coding sequence', 'nonsense'],
+        'biallelic inactivation' : ['bia'],
+        'overexpression' : ['expr'],
+        'unspecified' : ['na', 'n/a', 'gene variant', 'wild type', 'any'], # civic
+        'exon' : ['exon'], # civic
+        'transcript': ['transcript'], # civic
+        'loss of function' : ['loss of function'], # civic
+        'gain of function' : ['gain of function'], # civic
+        'frameshift' : ['frameshift'],
+        'loss of heterozygosity' : ['loss of heterozygosity'], # civic
+        'deletion' : ['deletion'],
+        'insertion' : ['insertion'],
+        '3 Prime UTR' : ['3 prime utr'],
+        'stopgain' : ['stop gained'],
+        'startloss' : ['start lost'],
+        'silent' : ['silent mutation', 'synonymous'],
+        'intron' : ['intron variant'],
+        'indel' : ['indel']
+    }
+
+    for mut in mut_types:
+        for opt in mut_types[mut]:
+            if opt in ev:
+                return mut
+            elif ev == "cna":
+                # Copy number alteration, either amplification or deletion.
+                # This is only relevant in the case of CGI 
+                if "amplification" in cgi_biomarker:
+                    return "amplification"
+                elif "deletion" in cgi_biomarker:
+                    return "deletion"
+    return ev

--- a/harvester/oncokb.py
+++ b/harvester/oncokb.py
@@ -9,6 +9,7 @@ LOOKUP_TABLE = cosmic_lookup_table.CosmicLookup("./cosmic_lookup_table.tsv")
 
 import evidence_label as el
 import evidence_direction as ed 
+import mutation_type as mut
 
 def harvest(genes):
     r = requests.get('http://oncokb.org/api/v1/levels')
@@ -47,10 +48,12 @@ def convert(gene_data):
         variant = clinical['variant']
         alteration = variant['alteration']
         gene_data = variant['gene']
+
         feature = {}
         feature['geneSymbol'] = gene
         feature['name'] = variant['name']
         feature['entrez_id'] = gene_data['entrezGeneId']
+        feature['biomarker_type'] = mut.norm_biomarker(variant['consequence']['term']) # NOQA
 
         # Look up variant and add position information.
         matches = LOOKUP_TABLE.get_entries(gene, alteration)

--- a/harvester/pmkb.py
+++ b/harvester/pmkb.py
@@ -8,6 +8,7 @@ from inflection import parameterize, underscore
 import json
 import evidence_label as el
 import evidence_direction as ed
+import mutation_type as mut
 
 def _eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
@@ -56,6 +57,8 @@ def convert(interpretation):
                 feature['end'] = stop
                 feature['chromosome'] = str(chromosome)
                 feature['referenceName'] = 'GRCh37/hg19'
+                feature['biomarker_type'] = mut.norm_biomarker(variant['variant_type'])
+
                 attributes = {}
                 for key in variant.keys():
                     if key not in ['coordinates', 'name', 'gene']:


### PR DESCRIPTION
'Mutation_type' module controls biomarker normalization for all sources. Original biomarker normalization function for CGI has been moved/incorporated there. 

Molecularmatch on hold until use of API is available again. 

Oncokb and jax biomarker info is either not available or available by different API requests. Additional call will need to be made. Secondary pr. 

