### PR TITLE
remove basic auth; shutdown online kibana admin

### DIFF
--- a/services/nginx/authorize-aws.lua
+++ b/services/nginx/authorize-aws.lua
@@ -104,21 +104,20 @@ local restrictions = {
     ["/_aliases"]                       = { "GET" },
     ["/_cluster.*"]                     = { "GET" },
 
-    ["/app.*"]                          = { "GET" },
-    ["/ui.*"]                           = { "GET" },
-    ["/bundles.*"]                      = { "GET" },
-    ["/api.*"]                          = { "GET", "POST" },
-    ["/plugins.*"]                      = { "GET" },
+    ["/_plugin/app.*"]                          = { "GET" },
+    ["/_plugin/ui.*"]                           = { "GET" },
+    ["/_plugin/bundles.*"]                      = { "GET" },
+    ["/_plugin/api.*"]                          = { "GET", "POST" },
+    ["/_plugin/plugins.*"]                      = { "GET" },
 
-    ["/es_admin.*"]                     = { "GET" },
-    ["/es_admin.*/_search"]             = { "GET", "POST" },
-    ["/es_admin.*/_msearch"]            = { "GET", "POST" },
-    ["/es_admin.*/_mget"]               = { "GET", "POST" },
+    ["/_plugin/.*/es_admin.*"]                     = { "GET" },
+    ["/*/_search"]                              = { "GET", "POST" },
+    ["/.*/_msearch"]                            = { "GET", "POST" },
+    ["/*/_mget"]                                = { "GET", "POST" },
 
-    ["/static.*"]                       = { "GET" },
+    ["/_plugin/static.*"]                       = { "GET" },
+    ["/_plugin/.*"]                             = { "GET" },
 
-    ["/kibana"]                       = { "GET", "POST" },
-    ["/elastic"]                      = { "GET", "POST" }
   }
 
 }

--- a/services/nginx/authorize.lua
+++ b/services/nginx/authorize.lua
@@ -91,7 +91,8 @@ local restrictions = {
     ["/plugins.*"]                      = { "GET" },
     ["/es_admin.*"]                     = { "GET", "POST" },
 
-    ["/static.*"]                       = { "GET" }
+    ["/static.*"]                       = { "GET" },
+    ["/admin.*"]                        = { "GET" }
 
   },
 

--- a/services/nginx/nginx_authorize_by_lua-aws.conf
+++ b/services/nginx/nginx_authorize_by_lua-aws.conf
@@ -36,9 +36,9 @@ http {
   # redirect users to https
   server {
     listen                          80;
-    server_name                     localhost; # g2p-ohsu.ddns.net;  # change this to your host
+    server_name                     g2p-ohsu.ddns.net;  # change this to your host
     location / {
-      return 301                    https://$server_name$request_uri;
+      return 301                      https://$server_name$request_uri;
     }
   }
 
@@ -52,7 +52,7 @@ http {
 
 
     # basic authentication for all access
-    # auth_basic           "foobar";
+    # auth_basic           "Protected Resource";
     # auth_basic_user_file .htpasswd;
     # authorization code
     access_by_lua_file  conf/authorize.lua;
@@ -73,21 +73,21 @@ http {
     }
 
     # asked for kibana
-    location /kibana {
-      rewrite /kibana/(.*) /$1 break;
-      proxy_pass                              http://kibana:5601;
-      proxy_buffering                         off;
-      proxy_pass_request_headers              on;
-      proxy_set_header Authorization          "";
-      proxy_set_header Host                   $http_host;
-      proxy_set_header X-Real-IP              $remote_addr;
-      proxy_set_header X-Forwarded-For        $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto      $scheme;
-    }
+    # location /kibana {
+    #   rewrite /kibana/(.*) /$1 break;
+    #   proxy_pass                              http://kibana:5601;
+    #   proxy_buffering                         off;
+    #   proxy_pass_request_headers              on;
+    #   proxy_set_header Authorization          "";
+    #   proxy_set_header Host                   $http_host;
+    #   proxy_set_header X-Real-IP              $remote_addr;
+    #   proxy_set_header X-Forwarded-For        $proxy_add_x_forwarded_for;
+    #   proxy_set_header X-Forwarded-Proto      $scheme;
+   #  }
 
     # asked for elastic search
     location / {
-      proxy_pass                              http://elastic:9200;
+      proxy_pass                              http://search-g2p-ohsu-fnuiztbjyxhivlq6aufmp6bfum.us-west-2.es.amazonaws.com;
       proxy_buffering                         off;
       proxy_pass_request_headers              on;
       proxy_set_header Authorization          "";

--- a/services/nginx/nginx_authorize_by_lua.conf
+++ b/services/nginx/nginx_authorize_by_lua.conf
@@ -74,9 +74,11 @@ http {
       # basic authentication for all access
       auth_basic           "admin";
       auth_basic_user_file .htpasswd;
-      rewrite ^ /kibana ;      
+      error_page 404 = @admin;
     }
-
+    location @admin {
+      rewrite  ^ /kibana/app/kibana;
+    }
 
     # asked for kibana
     location /kibana {

--- a/services/nginx/nginx_authorize_by_lua.conf
+++ b/services/nginx/nginx_authorize_by_lua.conf
@@ -36,7 +36,7 @@ http {
   # redirect users to https
   server {
     listen                          80;
-    server_name                     localhost; # g2p-ohsu.ddns.net;  # change this to your host
+    server_name                     g2p-ohsu.ddns.net;  # change this to your host
     location / {
       return 301                    https://$server_name$request_uri;
     }

--- a/services/nginx/nginx_authorize_by_lua.conf
+++ b/services/nginx/nginx_authorize_by_lua.conf
@@ -36,7 +36,7 @@ http {
   # redirect users to https
   server {
     listen                          80;
-    server_name                     g2p-ohsu.ddns.net;  # change this to your host
+    server_name                     localhost; # g2p-ohsu.ddns.net;  # change this to your host
     location / {
       return 301                    https://$server_name$request_uri;
     }
@@ -51,9 +51,6 @@ http {
     ssl_certificate_key             /certs/privkey.pem;
 
 
-    # basic authentication for all access
-    # auth_basic           "foobar";
-    # auth_basic_user_file .htpasswd;
     # authorization code
     access_by_lua_file  conf/authorize.lua;
 
@@ -71,6 +68,15 @@ http {
     location /static-html {
      root /var/www;
     }
+
+    # administration
+    location /admin {
+      # basic authentication for all access
+      auth_basic           "admin";
+      auth_basic_user_file .htpasswd;
+      rewrite ^ /kibana ;      
+    }
+
 
     # asked for kibana
     location /kibana {


### PR DESCRIPTION
This PR has two new features:
* removes basic auth addresses #27 
* as a consequence, we shutdown online maintenance of kibana
This has been deployed on dms-dev & g2p-ohsu.ddns.net

@jgoecks @mayfielg : let me know if there are impacts
