### PR TITLE
gene_aliases

### DIFF
--- a/harvester/feature_enricher.py
+++ b/harvester/feature_enricher.py
@@ -156,7 +156,9 @@ def enrich(feature, feature_association):
         def _is_gene(symbols):
             """ return true if all symbols exist"""
             for symbol in symbols:
-                if not gene_enricher.get_genes(symbol):
+                try:
+                    gene = gene_enricher.get_gene(symbol)
+                except ValueError:
                     return False
             return True
 

--- a/harvester/feature_enricher.py
+++ b/harvester/feature_enricher.py
@@ -156,7 +156,7 @@ def enrich(feature, feature_association):
         def _is_gene(symbols):
             """ return true if all symbols exist"""
             for symbol in symbols:
-                if not gene_enricher.get_gene(symbol):
+                if not gene_enricher.get_genes(symbol):
                     return False
             return True
 

--- a/harvester/gene_enricher.py
+++ b/harvester/gene_enricher.py
@@ -35,20 +35,23 @@ for doc in data['response']['docs']:
 data = None
 
 
-def get_genes(identifier):
+def get_gene(identifier):
     """ return gene for identifier """
     for store in [GENES, ALIASES]:
         genes = store.get(identifier, None)
-        if genes:
+        if genes and len(genes) == 1:
             return genes
-    return None
-
+        else:
+            raise ValueError('gene reference does not exist or refers to multiple genes')
 
 def normalize_feature_association(feature_association):
     """ add gene_identifiers array to feature_association """
     gene_identifiers = []
     for gene_symbol in feature_association['genes']:
-        genes = get_genes(gene_symbol)
-        if (genes):
-            gene_identifiers.extend(genes)
+        try:
+            gene = get_gene(gene_symbol)
+        except:
+            gene = None
+        if (gene):
+            gene_identifiers.extend(gene)
     feature_association['gene_identifiers'] = gene_identifiers

--- a/harvester/gene_enricher.py
+++ b/harvester/gene_enricher.py
@@ -15,22 +15,40 @@ for doc in data['response']['docs']:
         'ensembl_gene_id': doc.get('ensembl_gene_id', None),
         'entrez_id': doc.get('entrez_id', None)
         }
-    GENES[doc['symbol']] = gene
+    GENES[doc['symbol']] = [gene]
     if gene['ensembl_gene_id']:
-        ALIASES[gene['ensembl_gene_id']] = gene
+        if gene['ensembl_gene_id'] not in ALIASES:
+            ALIASES[gene['ensembl_gene_id']] = []
+        ALIASES[gene['ensembl_gene_id']].append(gene)
     if gene['entrez_id']:
-        ALIASES[gene['entrez_id']] = gene
+        if gene['entrez_id'] not in ALIASES:
+            ALIASES[gene['entrez_id']] = []
+        ALIASES[gene['entrez_id']].append(gene)
     for alias in doc.get('alias_symbol', []):
-        ALIASES[alias] = gene
+        if alias not in ALIASES:
+            ALIASES[alias] = []
+        ALIASES[alias].append(gene)
     for prev in doc.get('prev_symbol', []):
-        ALIASES[prev] = gene
+        if prev not in ALIASES:
+            ALIASES[prev] = []
+        ALIASES[prev].append(gene)
 data = None
 
 
-def get_gene(identifier):
+def get_genes(identifier):
     """ return gene for identifier """
     for store in [GENES, ALIASES]:
-        gene = store.get(identifier, None)
-        if gene:
-            return gene
+        genes = store.get(identifier, None)
+        if genes:
+            return genes
     return None
+
+
+def normalize_feature_association(feature_association):
+    """ add gene_identifiers array to feature_association """
+    gene_identifiers = []
+    for gene_symbol in feature_association['genes']:
+        genes = get_genes(gene_symbol)
+        if (genes):
+            gene_identifiers.extend(genes)
+    feature_association['gene_identifiers'] = gene_identifiers

--- a/harvester/harvester.py
+++ b/harvester/harvester.py
@@ -27,6 +27,7 @@ import jax_trials
 import drug_normalizer
 import disease_normalizer
 import reference_genome_normalizer
+import gene_enricher
 
 from elastic_silo import ElasticSilo
 import elastic_silo
@@ -158,6 +159,11 @@ def normalize(feature_association):
     biomarker_normalizer.normalize_feature_association(feature_association)
     if elapsed > 1:
         logging.info('biomarker_normalizer {}'.format(elapsed))
+
+    start_time = timeit.default_timer()
+    gene_enricher.normalize_feature_association(feature_association)
+    if elapsed > 1:
+        logging.info('gene_enricher {}'.format(elapsed))
 
 
 def main():

--- a/harvester/molecularmatch_trials.py
+++ b/harvester/molecularmatch_trials.py
@@ -8,7 +8,6 @@ import logging
 from warnings import warn
 import sys
 import time
-import gene_enricher
 
 DEFAULT_GENES = ['*']
 TRIAL_IDS = []
@@ -140,8 +139,7 @@ def convert(evidence):
         genes = set([])
         for t in evidence_tags:
             if t['facet'] == 'GENE':
-                if gene_enricher.get_genes(t['term']):
-                    genes.add(t['term'])
+                genes.add(t['term'])
         genes = list(genes)
 
         features = set([])

--- a/harvester/molecularmatch_trials.py
+++ b/harvester/molecularmatch_trials.py
@@ -8,6 +8,7 @@ import logging
 from warnings import warn
 import sys
 import time
+import gene_enricher
 
 DEFAULT_GENES = ['*']
 TRIAL_IDS = []
@@ -139,7 +140,8 @@ def convert(evidence):
         genes = set([])
         for t in evidence_tags:
             if t['facet'] == 'GENE':
-                genes.add(t['term'])
+                if gene_enricher.get_genes(t['term']):
+                    genes.add(t['term'])
         genes = list(genes)
 
         features = set([])

--- a/harvester/tests/integration/test_gene_enricher.py
+++ b/harvester/tests/integration/test_gene_enricher.py
@@ -5,6 +5,27 @@ import gene_enricher  # NOQA
 
 
 def test_simple():
-    tp53 = gene_enricher.get_gene('TP53')
+    tp53 = gene_enricher.get_genes('TP53')
     assert(tp53)
-    assert tp53 == {'ensembl_gene_id': u'ENSG00000141510'}
+    assert tp53 == [{'symbol': u'TP53', 'entrez_id': u'7157',
+                    'ensembl_gene_id': u'ENSG00000141510'}]
+
+
+def test_simple_normalize_feature_association():
+    feature_association = {'genes': ['TP53']}
+    gene_enricher.normalize_feature_association(feature_association)
+    print feature_association['gene_identifiers']
+    assert 'gene_identifiers' in feature_association
+    assert feature_association['gene_identifiers'] == [
+        {'symbol': u'TP53', 'entrez_id': u'7157',
+         'ensembl_gene_id': u'ENSG00000141510'}
+         ]
+
+
+def test_ambiguous():
+    """ "ABC1" can point to both "ABCA1" and "HEATR6", """
+    genes = gene_enricher.get_genes('ABC1')
+    assert genes == [
+        {'symbol': u'ABCA1', 'entrez_id': u'19', 'ensembl_gene_id': u'ENSG00000165029'},
+        {'symbol': u'HEATR6', 'entrez_id': u'63897', 'ensembl_gene_id': u'ENSG00000068097'}
+    ]


### PR DESCRIPTION
This PR has two features:
* addresses normalize genes, introduces a `gene_identifiers` #102 
* addresses improper split of civic evidence features, by looking up genes as part of fusion normalization #99

[Bucket 0.10](https://s3.console.aws.amazon.com/s3/buckets/g2p-0.10) and [g2p-test](https://g2p-test.ddns.net) has been updated