### PR TITLE
PMKB changes; parent_soid becomes root_soid; multiple phenotype capabilities

### DIFF
--- a/harvester/biomarker_normalizer.py
+++ b/harvester/biomarker_normalizer.py
@@ -55,11 +55,11 @@ def get_soid_data(soid):
                 parent = data['parents'].split(',')[0]
                 btype = get_soid_data(parent)
                 if btype['hierarchy']:
-                    bsubtype['parent_soid'] = btype['parent_soid']
-                    bsubtype['parent_name'] = btype['parent_name']
+                    bsubtype['root_soid'] = btype['root_soid']
+                    bsubtype['root_name'] = btype['root_name']
                 else:
-                    bsubtype['parent_soid'] = btype['soid']
-                    bsubtype['parent_name'] = btype['name']
+                    bsubtype['root_soid'] = btype['soid']
+                    bsubtype['root_name'] = btype['name']
                 btype['hierarchy'].append(btype['soid'])
                 bsubtype['hierarchy'] = btype['hierarchy']
         except:
@@ -112,8 +112,8 @@ def normalize_feature_association(feature_association):
             feat['sequence_ontology'] = {
                 'soid': '',
                 'name': 'Uncategorized',
-                'parent_soid': '',
-                'parent_name': 'Uncategorized',
+                'root_soid': '',
+                'root_name': 'Uncategorized',
             }
             continue
         # Currently only dealing with a exact matches

--- a/harvester/brca.py
+++ b/harvester/brca.py
@@ -54,10 +54,7 @@ def convert(gene_data):
         association['description'] = brca['Pathogenicity_expert']
         association['environmentalContexts'] = []
         if not brca['Condition_ID_value_ENIGMA'] == '-':
-            association['phenotype'] = {
-                'description': brca['Condition_ID_value_ENIGMA'],
-                # 'id': ?
-            }
+            association['phenotypes'] = [{ 'description': brca['Condition_ID_value_ENIGMA'] }]
 
         citations = brca['Clinical_significance_citations_ENIGMA']
         info = None

--- a/harvester/cgi_biomarkers.py
+++ b/harvester/cgi_biomarkers.py
@@ -172,13 +172,9 @@ def convert(evidence):
     association['environmentalContexts'] = []
     association['environmentalContexts'].append({
         'description': evidence['Drug full name']})
-    phenotype_description = evidence['Primary Tumor type']
+    association['phenotypes'] = [{ 'description' : evidence['Primary Tumor type']} ]
     if not evidence['Metastatic Tumor Type'] == '':
-        phenotype_description = '{} {}'.format(
-                phenotype_description, evidence['Metastatic Tumor Type'])
-    association['phenotype'] = {
-        'description': phenotype_description
-    }
+        association['phenotypes'].append({ 'description' : evidence['Metastatic Tumor Type'] })
 
     pubs = []
     for p in evidence['Source'].split(';'):

--- a/harvester/civic.py
+++ b/harvester/civic.py
@@ -76,10 +76,7 @@ def convert(gene_data):
                         'description': drug['name'],
                         'id': drug['pubchem_id']
                     })
-                association['phenotype'] = {
-                    'description': evidence_item['disease']['name'],
-                    'id': evidence_item['disease']['url']
-                }
+                association['phenotypes'] = [evidence_item['disease']['name']]
                 association['evidence'] = [{
                     "evidenceType": {
                         "sourceName": "CIVIC",

--- a/harvester/disease_normalizer.py
+++ b/harvester/disease_normalizer.py
@@ -192,7 +192,7 @@ def normalize(name):
 def normalize_multi(phenotypes):
     diseases = []
     for pheno in phenotypes:
-        disease = normalize(pheno)
+        disease = normalize(pheno['description'])
         phenotype = {
             'id': disease[0]['ontology_term'],
             'term': disease[0]['label'],
@@ -210,27 +210,16 @@ def normalize_feature_association(feature_association):
     update it with normalized diseases """
     # nothing to read?, return
     association = feature_association['association']
-    if 'phenotypes' in association:
-        diseases = normalize_multi(association['phenotypes'])
-        association['phenotypes'] = diseases
-    if 'phenotype' not in association:
+    if 'phenotypes' not in association:
         return
-    diseases = normalize(association['phenotype']['description'])
+    diseases = normalize_multi(association['phenotypes'])
     if len(diseases) == 0:
         feature_association['dev_tags'].append('no-doid')
-        association['phenotype']['family'] = 'Uncategorized-PHN'
+        for i in range(len(association['phenotypes'])):
+            association['phenotypes'][i]['family'] = 'Uncategorized-PHN'
         return
-    # TODO we are only looking for exact match of one disease right now
-    association['phenotype']['type'] = {
-        'id': diseases[0]['ontology_term'],
-        'term': diseases[0]['label'],
-        'source': diseases[0]['source']
-    }
-    if 'family' in diseases[0]:
-        association['phenotype']['family'] = diseases[0]['family']
-    else:
-        association['phenotype']['family'] = 'Uncategorized-PHN'
-    association['phenotype']['description'] = diseases[0]['label']
+    association['phenotypes'] = diseases
+    return
 
 
 def project_lookup(name):

--- a/harvester/disease_normalizer.py
+++ b/harvester/disease_normalizer.py
@@ -212,7 +212,7 @@ def normalize_feature_association(feature_association):
     association = feature_association['association']
     if 'phenotypes' in association:
         diseases = normalize_multi(association['phenotypes'])
-        association['phenotypes_info'] = diseases
+        association['phenotypes'] = diseases
     if 'phenotype' not in association:
         return
     diseases = normalize(association['phenotype']['description'])

--- a/harvester/disease_normalizer.py
+++ b/harvester/disease_normalizer.py
@@ -55,7 +55,7 @@ def normalize_bioontology(name):
 def normalize_ebi(name):
     """ call ebi & retrieve """
     if name in NOFINDS:
-        logging.info('{} in disease_normalizer.NOFINDS'.format(name))
+        # logging.info('{} in disease_normalizer.NOFINDS'.format(name))
         return []
     name = urllib.quote_plus(project_lookup(name))
     url = 'https://www.ebi.ac.uk/ols/api/search?q={}&groupField=iri&exact=on&start=0&ontology=doid'.format(name)  # NOQA
@@ -189,11 +189,30 @@ def normalize(name):
         return []
 
 
+def normalize_multi(phenotypes):
+    diseases = []
+    for pheno in phenotypes:
+        disease = normalize(pheno)
+        phenotype = {
+            'id': disease[0]['ontology_term'],
+            'term': disease[0]['label'],
+            'source': disease[0]['source'],
+            'description': disease[0]['label']
+        }
+        if 'family' in disease[0]:
+            phenotype['family'] = disease[0]['family']
+        diseases.append(phenotype)
+    return diseases
+
+
 def normalize_feature_association(feature_association):
     """ given the 'final' g2p feature_association,
     update it with normalized diseases """
     # nothing to read?, return
     association = feature_association['association']
+    if 'phenotypes' in association:
+        diseases = normalize_multi(association['phenotypes'])
+        association['phenotypes_info'] = diseases
     if 'phenotype' not in association:
         return
     diseases = normalize(association['phenotype']['description'])

--- a/harvester/harvester.py
+++ b/harvester/harvester.py
@@ -132,7 +132,7 @@ def normalize(feature_association):
     disease_normalizer.normalize_feature_association(feature_association)
     elapsed = timeit.default_timer() - start_time
     if elapsed > 1:
-        disease = feature_association['association']['phenotype']['description']
+        disease = feature_association['association']['phenotypes'][0]['description']
         logging.info('disease_normalizer {} {}'.format(elapsed, disease))
 
     start_time = timeit.default_timer()

--- a/harvester/jax.py
+++ b/harvester/jax.py
@@ -223,7 +223,8 @@ def convert(jax_evidence):
     association['environmentalContexts'].append({
         'description': evidence.therapy.therapyName})
     association['phenotypes'] = [{ 'description' : evidence.indication.name,
-                                   'id' :  '{}:{}'.format(i.source, i.id) }]
+                                   'id' :  '{}:{}'.format(evidence.indication.source, 
+                                                          evidence.indication.id) }]
     association['evidence'] = [{
         "evidenceType": {
             "sourceName": "jax"

--- a/harvester/jax.py
+++ b/harvester/jax.py
@@ -222,11 +222,8 @@ def convert(jax_evidence):
     association['environmentalContexts'] = []
     association['environmentalContexts'].append({
         'description': evidence.therapy.therapyName})
-    i = evidence.indication
-    association['phenotype'] = {
-        'description': i.name,
-        'type': {'term': '{}:{}'.format(i.source, i.id)}
-    }
+    association['phenotypes'] = [{ 'description' : evidence.indication.name,
+                                   'id' :  '{}:{}'.format(i.source, i.id) }]
     association['evidence'] = [{
         "evidenceType": {
             "sourceName": "jax"

--- a/harvester/jax_trials.py
+++ b/harvester/jax_trials.py
@@ -209,10 +209,12 @@ def convert(jax_evidence):
     for therapy in evidence['therapies']:
         association['environmentalContexts'].append({
             'description': therapy['therapyName']})
+    association['phenotypes'] = []
     for indication in evidence['indications']:
-        association['phenotype'] = {
-            'description': indication['name']
-        }
+        s = { 'description' : indication['name'], 
+              'id' : '{}:{}'.format(i.source, i.id) }
+        association['phenotypes'].append(s)
+
     association['evidence'] = [{
         "evidenceType": {
             "sourceName": "jax-trials"

--- a/harvester/molecularmatch.py
+++ b/harvester/molecularmatch.py
@@ -120,13 +120,14 @@ def convert(evidence):
     clinicalSignificance = evidence['clinicalSignificance']
     tags = evidence['tags']
     gene = None
-    condition = None
+    condition = []
     mutation = None
+
     for tag in tags:
         if tag['facet'] == 'GENE' and tag['priority'] == 1:
             gene = tag['term']
-        if tag['facet'] == 'CONDITION' and tag['priority'] == 1:
-            condition = tag['term']
+        if tag['facet'] == 'CONDITION':
+            condition.append({ 'description': tag['term'] })
         if tag['facet'] == 'MUTATION' and tag['priority'] == 1:
             mutation = tag['term']
         if tag['facet'] == 'PHRASE' and 'ISOFORM EXPRESSION' in tag['term']:
@@ -217,9 +218,8 @@ def convert(evidence):
     association['environmentalContexts'] = []
     association['environmentalContexts'].append({
         'description': drug_label})
-    association['phenotype'] = {
-        'description': condition
-    }
+
+    association['phenotypes'] = condition
 
     pubs = []
     for p in sources:

--- a/harvester/oncokb.py
+++ b/harvester/oncokb.py
@@ -178,9 +178,7 @@ def convert(gene_data):
         association['environmentalContexts'] = []
         for drug in clinical['drug'].split(', '):
             association['environmentalContexts'].append({'description': drug})
-        association['phenotype'] = {
-            'description': clinical['cancerType'],
-        }
+        association['phenotypes'] = [{ 'description': clinical['cancerType'] }]
 
         # grab all publications from abstracts or PMIDs for piblication list
         abstract = []

--- a/harvester/pmkb.py
+++ b/harvester/pmkb.py
@@ -78,17 +78,10 @@ def convert(interpretation):
     # TODO pmkb does not break out drug !?!?
     # association['environmentalContexts'] = []
 
-    desc = []
+    association['phenotypes'] = []
     for tumor in tumors:
-        desc.append(tumor['name'])
-    association['phenotypes'] = desc
-    if len(desc) > 0:
-        t = desc[0]
-    else:
-        t = ''
-    association['phenotype'] = {
-         'description': t
-    }
+        association['phenotypes'].append({ 'description': tumor['name'] })
+
     association['drug_labels'] = 'NA'
     association['evidence'] = [{
          "evidenceType": { "sourceName": "pmkb" },

--- a/harvester/pmkb.py
+++ b/harvester/pmkb.py
@@ -12,7 +12,11 @@ def harvest(genes=None):
         for line in ins:
             interpretations = json.loads(line)['interpretations']
             for interpretation in interpretations:
-                yield interpretation
+                if not genes:
+                    yield interpretation
+                else:
+                    if interpretation['gene']['name'] in genes:
+                        yield interpretation
 
 
 def convert(interpretation):
@@ -77,8 +81,13 @@ def convert(interpretation):
     desc = []
     for tumor in tumors:
         desc.append(tumor['name'])
+    association['phenotypes'] = desc
+    if len(desc) > 0:
+        t = desc[0]
+    else:
+        t = ''
     association['phenotype'] = {
-         'description': desc
+         'description': t
     }
     association['drug_labels'] = 'NA'
     association['evidence'] = [{
@@ -93,6 +102,7 @@ def convert(interpretation):
         # add summary fields for Display
    #     if len(interpretation['citations']) > 0:
    #          association['publication_url'] = 'http://www.ncbi.nlm.nih.gov/pubmed/{}'.format(interpretation['citations'][0]['pmid'])  # NOQA
+    association['publication_url'] = ''
     feature_association = {'genes': [genes],
                            'features': features,
                            'feature_names': ['{} {}'.format(f["geneSymbol"], f["name"]) for f in features],

--- a/harvester/pmkb.py
+++ b/harvester/pmkb.py
@@ -16,15 +16,20 @@ def harvest(genes=None):
 
 
 def convert(interpretation):
-    """create feature_association from pmkb evidence"""
-    for variant in interpretation['variants']:
-        if 'coordinates' in variant:
-            # '7:140453135-140453136'
-            # '3:41266097-41266099, 3:41266100-41266102, 3:41266103-41266105, 3:41266106-41266108, 3:41266109-41266111, 3:41266112-41266114, 3:41266124-41266126, 3:41266136-41266138'  # NOQA
-            s = variant['coordinates']
-            if not s:
-                continue
-            coordinates = s.replace(' ', '').split(',')
+    # for each interpretation
+    association = {}
+    genes = interpretation['gene']['name']
+    variants = interpretation['variants']
+    tumors = interpretation['tumors']
+
+    features = []
+    variant_name = []
+    for variant in variants:
+	if 'coordinates' in variant:
+	    s = variant['coordinates']
+            if not s: 
+		continue
+	    coordinates = s.replace(' ', '').split(',')
             for coordinate in coordinates:
                 feature = {}
                 feature['geneSymbol'] = variant['gene']['name']
@@ -44,70 +49,61 @@ def convert(interpretation):
                         attributes[key] = {'string_value': variant[key]}
                 feature['attributes'] = attributes
 
-                # TODO - replace w/ biocommons/hgvs ?
-                if 'dna_change' in variant:
-                    dna_change = variant['dna_change']
-                    if dna_change and '>' in dna_change:
-                        prefix, alt = dna_change.split('>')
-                        ref = prefix[-len(alt):]
-                        if len(ref) > 0 and len(alt) > 0:
-                            feature['ref'] = ref
-                            feature['alt'] = alt
+        # TODO - replace w/ biocommons/hgvs ?
+        if 'dna_change' in variant:
+            dna_change = variant['dna_change']
+            if dna_change and '>' in dna_change:
+                prefix, alt = dna_change.split('>')
+                ref = prefix[-len(alt):]
+                if len(ref) > 0 and len(alt) > 0:
+                    feature['ref'] = ref
+                    feature['alt'] = alt
 
-                gene = variant['gene']['name']
+        if attributes['amino_acid_change']['string_value']:
+	    variant_name.append(attributes['amino_acid_change']['string_value'])
 
-                association = {}
+	features.append(feature)
 
-                if attributes['amino_acid_change']['string_value']:
-                    association['variant_name'] = attributes['amino_acid_change']['string_value']
+    # association['evidence_label'] = interpretation['tier']
+    association['source_link'] = 'https://pmkb.weill.cornell.edu/therapies/{}'.format(interpretation['id'])
 
-                # association['evidence_label'] = interpretation['tier']
-                association['source_link'] = 'https://pmkb.weill.cornell.edu/variants/{}'.format(variant['id'])
-                association = el.evidence_label(str(interpretation['tier']),
-                                                association, na=True)
-                association = ed.evidence_direction(
-                                str(interpretation['tier']),
-                                association, na=True)
+    association = el.evidence_label(str(interpretation['tier']), association, na=True)
+    association = ed.evidence_direction(str(interpretation['tier']), association, na=True)
 
-                association['description'] = interpretation['interpretation']
-                # TODO pmkb does not break out drug !?!?
-                # association['environmentalContexts'] = []
+    association['description'] = interpretation['interpretation']
+    # TODO pmkb does not break out drug !?!?
+    # association['environmentalContexts'] = []
 
-                for tumor in interpretation['tumors']:
-                    association['phenotype'] = {
-                        'description': tumor['name']
-                    }
-                    association['drug_labels'] = 'NA'
-                    association['evidence'] = [{
-                        "evidenceType": {
-                            "sourceName": "pmkb"
-                        },
-                        'description': str(interpretation['tier']),
-                        'info': {
-                            'publications': [
-                                'http://www.ncbi.nlm.nih.gov/pubmed/{}'.format(c['pmid']) for c in interpretation['citations']  # NOQA
-                            ]
-                        }
-                    }]
-                    # add summary fields for Display
-                    if len(interpretation['citations']) > 0:
-                        association['publication_url'] = 'http://www.ncbi.nlm.nih.gov/pubmed/{}'.format(interpretation['citations'][0]['pmid'])  # NOQA
-                    feature_association = {'genes': [gene],
-                                           'features': [feature],
-                                           'feature_names':
-                                           '{} {}'.format(
-                                                feature["geneSymbol"],
-                                                feature["name"]
-                                            ),
-                                           'association': association,
-                                           'source': 'pmkb',
-                                           'pmkb': {
-                                            'variant': variant,
-                                            'tumor': tumor,
-                                            'tissues':
-                                            interpretation['tissues']
-                                           }}
-                    yield feature_association
+    desc = []
+    for tumor in tumors:
+        desc.append(tumor['name'])
+    association['phenotype'] = {
+         'description': desc
+    }
+    association['drug_labels'] = 'NA'
+    association['evidence'] = [{
+         "evidenceType": { "sourceName": "pmkb" },
+         'description': str(interpretation['tier']),
+         'info': {
+             'publications': [
+    #             'http://www.ncbi.nlm.nih.gov/pubmed/{}'.format(c['pmid']) for c in interpretation['citations']  # NOQA
+             ]
+         }
+    }]
+        # add summary fields for Display
+   #     if len(interpretation['citations']) > 0:
+   #          association['publication_url'] = 'http://www.ncbi.nlm.nih.gov/pubmed/{}'.format(interpretation['citations'][0]['pmid'])  # NOQA
+    feature_association = {'genes': [genes],
+                           'features': features,
+                           'feature_names': ['{} {}'.format(f["geneSymbol"], f["name"]) for f in features],
+                           'association': association,
+                           'source': 'pmkb',
+                           'pmkb': {
+                               'variant': variants,
+                               'tumor': tumors,
+                               'tissues': interpretation['tissues']
+                           }}
+    yield feature_association
 
 
 def harvest_and_convert(genes):

--- a/harvester/sage.py
+++ b/harvester/sage.py
@@ -58,9 +58,7 @@ def convert(gene_data):
             )
             association = {
                 'description': description,
-                'phenotype': {
-                    'description': evidence_item['clinical_manifestation'],
-                },
+                'phenotypes': [{ 'description': evidence_item['clinical_manifestation'] }],
                 'evidence': [{
                     "evidenceType": {
                         "sourceName": "sage",

--- a/harvester/tests/integration/test_biomarker_normalizer.py
+++ b/harvester/tests/integration/test_biomarker_normalizer.py
@@ -24,8 +24,8 @@ def test_get_so_data():
     soid = get_soid_data(term)
     assert soid['soid'] == term
     assert soid['name'] == 'feature_amplification'
-    assert soid['parent_soid'] == 'SO:0001060'
-    assert soid['parent_name'] == 'sequence_variant'
+    assert soid['root_soid'] == 'SO:0001060'
+    assert soid['root_name'] == 'sequence_variant'
     assert len(soid['hierarchy']) == 2
 
 def test_normalize_amp():
@@ -33,8 +33,8 @@ def test_normalize_amp():
     soid = normalize(term)
     assert soid['soid'] == 'SO:0001880'
     assert soid['name'] == 'feature_amplification'
-    assert soid['parent_soid'] == 'SO:0001060'
-    assert soid['parent_name'] == 'sequence_variant'
+    assert soid['root_soid'] == 'SO:0001060'
+    assert soid['root_name'] == 'sequence_variant'
     assert len(soid['hierarchy']) == 2
 
 def test_normalize_amp():
@@ -42,8 +42,8 @@ def test_normalize_amp():
     soid = normalize(term)
     assert soid['soid'] == 'SO:1000002'
     assert soid['name'] == 'substitution'
-    assert soid['parent_soid'] == 'SO:0000110'
-    assert soid['parent_name'] == 'sequence_feature'
+    assert soid['root_soid'] == 'SO:0000110'
+    assert soid['root_name'] == 'sequence_feature'
     assert len(soid['hierarchy']) == 3
 
 def test_normalize_wildtype():
@@ -51,8 +51,8 @@ def test_normalize_wildtype():
     soid = normalize(term)
     assert soid['soid'] == 'SO:0000817'
     assert soid['name'] == 'wild_type'
-    assert soid['parent_soid'] == 'SO:0000400'
-    assert soid['parent_name'] == 'sequence_attribute'
+    assert soid['root_soid'] == 'SO:0000400'
+    assert soid['root_name'] == 'sequence_attribute'
     assert len(soid['hierarchy']) == 2
 
 def test_normalize_wildtype():
@@ -60,8 +60,8 @@ def test_normalize_wildtype():
     soid = normalize(term)
     assert soid['soid'] == 'SO:0002054'
     assert soid['name'] == 'loss_of_function_variant'
-    assert soid['parent_soid'] == 'SO:0001060'
-    assert soid['parent_name'] == 'sequence_variant'
+    assert soid['root_soid'] == 'SO:0001060'
+    assert soid['root_name'] == 'sequence_variant'
     assert len(soid['hierarchy']) == 2
 
 def test_uncategorized():
@@ -82,6 +82,6 @@ def test_get_so_data_0001587():
     soid = get_soid_data(term)
     assert soid['soid'] == term
     assert soid['name'] == 'stop_gained'
-    assert soid['parent_soid'] == 'SO:0001060'
-    assert soid['parent_name'] == 'sequence_variant'
+    assert soid['root_soid'] == 'SO:0001060'
+    assert soid['root_name'] == 'sequence_variant'
     assert len(soid['hierarchy']) == 10


### PR DESCRIPTION
This PR addresses: 
* https://github.com/ohsu-comp-bio/g2p-aggregator/issues/98
* https://github.com/ohsu-comp-bio/g2p-aggregator/issues/103

by reorganizing the PMKB harvester and changing the sequence ontology fields`parent_soid`and `parent_name` to `root_soid` and `root_name`. 

Harvester reorganization largely comes from moving focus from `variants` to `interpretations`. Previously, a single association was created per pmkb variant, now we have one feature per pmkb interpretation, which may contain multiple variants. 

Note: the pmkb harvester was/is pulling data from a `pmkb_interpretations.json` file. This file does not include any citation/publication data, so there is none to suck into the documents. Question for @bwalsh and @ahwagner: where did this file come from before being loading to s3? Can it be updated to include citation information? 

This PR also begins the work related to https://github.com/ohsu-comp-bio/g2p-aggregator/issues/107. PMKB interpretations are almost entirely labeled with multiples. This work introduces a `association.phenotypes_info` field to deal with this. This field only works for the pmkb harvester so far. 