### PR TITLE
added disease aliases for HPids

### DIFF
--- a/harvester/disease_alias.tsv
+++ b/harvester/disease_alias.tsv
@@ -308,3 +308,17 @@ Childhood myelodysplastic syndrome	myelodysplastic syndrome
 Fanconi's hypoplastic anaemia	Fanconi anemia
 Malignant lymphoma - lymphoplasmacytic	lymphoplasmacytic lymphoma
 Trabecular cell carcinoma of skin	Merkel cell carcinoma
+Endometrium	endometrial cancer
+Pancreas	Pancreatic Cancer
+Bladder	bladder cancer
+Stomach	stomach cancer
+Glioma	malignant glioma
+Glioblastoma	glioblastoma classical subtype
+Neoplasm of the larynx	larynx neoplasm
+Neoplasm of the head and neck	head and neck neoplasm
+Anaplastic thyroid carcinoma	thyroid carcinoma
+Myelodysplasia	myelodysplastic syndrome
+Single lineage myelodysplasia	myelodysplastic syndrome
+Congenital neutropenia	neutropenia
+Neoplasm of the colon	colon neoplasm
+Cutaneous leiomyoma	leiomyoma cutis

--- a/harvester/disease_alias.tsv
+++ b/harvester/disease_alias.tsv
@@ -322,3 +322,4 @@ Single lineage myelodysplasia	myelodysplastic syndrome
 Congenital neutropenia	neutropenia
 Neoplasm of the colon	colon neoplasm
 Cutaneous leiomyoma	leiomyoma cutis
+Myelodisplasic syndrome	myelodisplastic syndrome

--- a/harvester/disease_normalizer.py
+++ b/harvester/disease_normalizer.py
@@ -97,9 +97,13 @@ def normalize_ebi(name):
         NOFINDS.append(name)
         return []
     doc = response['docs'][0]
+    if doc['obo_id'][:2] != 'DO':
+        logging.info('{} in disease_normalizer.NOFINDS'.format(name))
+        NOFINDS.append(name)
+        return []
     term = {'ontology_term': doc['obo_id'].encode('utf8'),
             'label': doc['label'].encode('utf8'),
-            'source': 'http://purl.obolibrary.org/obo/doid'}
+            'source': doc['iri'].encode('utf8')}
     family = get_family(doc['obo_id'])
     if family:
         term['family'] = family


### PR DESCRIPTION
Addresses https://github.com/ohsu-comp-bio/g2p-aggregator/issues/106. Adds switch to `normalize_ebi` function to not pass a ontology match unless it is a DOID match, as well as adds several new aliases to `harvester/disease_alias.tsv` to match the known `UBERON` and `HP` errors to the DOIDs instead. 

Also maps `association.phenotype.type.source` field to the api responses's listed url rather than the basic `http://purl.obolibrary.org/obo/doid`.

I was unable to match a few phenotypes to DOIDs:
* lymphoproliferative disorder
* neoplasm of the stomach
* ischemic stroke
* insulin resistance

If the `normalize_ebi` function fails, the `normalize_bioontology` function attempts to find a match, and frequently returns non-DOID matches, such as `MEDORA` and `SNOMEDCT`. Leave this?